### PR TITLE
feat(acesso): Cria usuário e adiciona chave ssh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@ override.tf.json
 tfplan
 
 **/credentials
+
+# Ignore the following files about keys to connect to GCP
+key.json
+keys.json
+cred.json
+creds.json

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 | network | Nome da rede existente na GCP | `string` | n/a | sim |
 | subnetwork | Nome da subrede existente na GCP * foi definido o valor padrão para caso passe a NETWORK com o valor 'default' | `string` | `""` | não |
 | zone | Zona na Google Cloud | `string` | n/a | sim |
+| ssh_keys | Lista de chaves públicas para criar conta local juntamente com acesso SSH, separadas por quebra de linha | `string` | "" | não |
 | labels | Mapa de labels para nossa instância maneira | `map(string)` | n/a | sim |
 | tags | Lista de tags de rede associadas à instância | `list(string)` | n/a | sim |
 | metadata_startup_script | Script executado na inicialização do Sistema Operacional | `string` | "" | não |
@@ -34,3 +35,17 @@
 ## Saídas
 
 No outputs.
+
+## Orientações Extras
+
+Para uso da variável ssh_keys é necessário informar a string em um formato específico segundo a documentação do google <https://cloud.google.com/compute/docs/instances/adding-removing-ssh-keys>.
+
+exemplo:
+```
+<USUÁRIO1>:ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1MjEAAACFBAGNALqk5plP32GSTpho1XuqRz8xxbj+GCp7bFM5mWtgEcDAoLvccqq939IrqcDPemqJkkT2LCkCwcLsQYFjnnfswwF7SVFV9xFpiMTQEiNqmfJZRcsRbf+6MP4TnEB71KPGVCoUWSsGKfWO7CaFirTKtSi13BeQGFupwBtjHh/== <USUÁRIO1>
+<USUÁRIO2>:ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1MjEAAACFBAGNALqk5plP32GSTpho1XuqRz8xxbj+GCp7bFM5mWtgEcDAoLvccqq939IrqcDPemqJkkT2LCkCwcLsQYFjnnfswwF7SVFV9xFpiMTQEiNqmfJZRcsRbf+6MP4TnEB71KPGVCoUWSsGKfWO7CaFirTKtSi13BeQGFupwBtjHh/== <USUÁRIO2>
+...
+<USUÁRIO_N>:ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1MjEAAACFBAGNALqk5plP32GSTpho1XuqRz8xxbj+GCp7bFM5mWtgEcDAoLvccqq939IrqcDPemqJkkT2LCkCwcLsQYFjnnfswwF7SVFV9xFpiMTQEiNqmfJZRcsRbf+6MP4TnEB71KPGVCoUWSsGKfWO7CaFirTKtSi13BeQGFupwBtjHh/== <USUÁRIO_N>
+```
+
+**IMPORTANTE:** a variável ssh_keys não é uma lista de strings é somente uma string com quebra de linha == \n.

--- a/how-to-use-this-module/.env
+++ b/how-to-use-this-module/.env
@@ -4,3 +4,5 @@ REMOTE_MAKEFILE=https://raw.githubusercontent.com/mentoriaiac/Makefiles/${VERSIO
 TARGET_FOLDER=how-to-use-this-module
 TERRAFORM_VERSION=1.0.0
 TARGET_ENV=.env.terraform
+GCP_PROJECT=seu_project_id
+GCP_TERRAFORM_SA=terraform

--- a/how-to-use-this-module/.env.terraform
+++ b/how-to-use-this-module/.env.terraform
@@ -1,1 +1,3 @@
-GOOGLE_APPLICATION_CREDENTIALS=credentials/application_default_credentials.json
+GOOGLE_APPLICATION_CREDENTIALS=key.json
+GCP_PROJECT=seu_project_id
+GCP_TERRAFORM_SA=terraform

--- a/how-to-use-this-module/Makefile
+++ b/how-to-use-this-module/Makefile
@@ -17,5 +17,26 @@ ifneq ($(shell test -e $(INCLUDE_MAKEFILE) && echo -n yes),yes)
 endif
 
 ifdef INCLUDE_MAKEFILE
-	include ${INCLUDE_MAKEFILE}	
+	include ${INCLUDE_MAKEFILE}
 endif
+
+auth-create-sa: ## 1: Cria ServiceAccount
+	gcloud iam service-accounts create ${GCP_TERRAFORM_SA} \
+		--project ${GCP_PROJECT} \
+		--description="Terraform Service Account" \
+		--display-name="Terraform Service Account"
+
+auth-create-iam-policy: ## 2: Cria Policy 1
+	gcloud projects add-iam-policy-binding ${GCP_PROJECT} \
+    --member=serviceAccount:${GCP_TERRAFORM_SA}@${GCP_PROJECT}.iam.gserviceaccount.com \
+    --role=roles/compute.instanceAdmin.v1
+
+auth-create-add-policy: ## 3: Cria policy 2
+	gcloud projects add-iam-policy-binding ${GCP_PROJECT} \
+    --member=serviceAccount:${GCP_TERRAFORM_SA}@${GCP_PROJECT}.iam.gserviceaccount.com \
+    --role=roles/iam.serviceAccountUser
+
+auth-create-creds-file: ## 4: Gera arquivo de autenticação do google GCP
+	gcloud iam service-accounts \
+		keys create key.json \
+		--iam-account=${GCP_TERRAFORM_SA}@${GCP_PROJECT}.iam.gserviceaccount.com

--- a/how-to-use-this-module/Makefile
+++ b/how-to-use-this-module/Makefile
@@ -30,6 +30,9 @@ auth-create-iam-policy: ## 2: Cria Policy 1
 	gcloud projects add-iam-policy-binding ${GCP_PROJECT} \
     --member=serviceAccount:${GCP_TERRAFORM_SA}@${GCP_PROJECT}.iam.gserviceaccount.com \
     --role=roles/compute.instanceAdmin.v1
+	gcloud projects add-iam-policy-binding ${GCP_PROJECT} \
+    --member=serviceAccount:${GCP_TERRAFORM_SA}@${GCP_PROJECT}.iam.gserviceaccount.com \
+    --role=roles/compute.networkAdmin
 
 auth-create-add-policy: ## 3: Cria policy 2
 	gcloud projects add-iam-policy-binding ${GCP_PROJECT} \

--- a/how-to-use-this-module/terrafile.tf
+++ b/how-to-use-this-module/terrafile.tf
@@ -1,6 +1,6 @@
 module "compute_gcp" {
   source         = "./.."
-  project        = "seuprojeto"
+  project        = "seu_projeto_id"
   instance_name  = "nomedainstancia"
   instance_image = "debian-cloud/debian-10"
   machine_type   = "e2-small"
@@ -8,6 +8,11 @@ module "compute_gcp" {
   network        = "default"
 
   metadata_startup_script = "echo 'Hello Mentoria' > /tmp/hello.txt"
+
+  ssh_keys = <<-EOT
+                debian:ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1MjEAAACFBAGNALqk5plP32GSTpho1XuqRz8xxbj+GCp7bFM5mWtgEcDAoLvccqq939IrqcDPemqJkkT2LCkCwcLsQYFjnnfswwF7SVFV9xFpiMTQEiNqmfJZRcsRbf+6MP4TnEB71KPGVCoUWSsGKfWO7CaFirTKtSi13BeQGFupwBtjHh/== debian
+                ubuntu:ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1MjEAAACFBAGNALqk5plP32GSTpho1XuqRz8xxbj+GCp7bFM5mWtgEcDAoLvccqq939IrqcDPemqJkkT2LCkCwcLsQYFjnnfswwF7SVFV9xFpiMTQEiNqmfJZRcsRbf+6MP4TnEB71KPGVCoUWSsGKfWO7CaFirTKtSi13BeQGFupwBtjHh/== ubuntu
+            EOT
 
   labels = {
     value = "key"

--- a/how-to-use-this-module/terrafile.tf
+++ b/how-to-use-this-module/terrafile.tf
@@ -20,3 +20,13 @@ module "compute_gcp" {
 
   tags = ["mentoriaiac"]
 }
+
+output "instance_public_ip" {
+  description = "The public IP of the instance"
+  value       = module.compute_gcp.instance_public_ip
+}
+
+output "instance_private_ip" {
+  description = "The private IP of the instance"
+  value       = module.compute_gcp.instance_private_ip
+}

--- a/how-to-use-this-module/terraform.inc
+++ b/how-to-use-this-module/terraform.inc
@@ -68,6 +68,10 @@ terraform-destroy: ## Execute terraform destroy in terraform files
 	echo "STEP: terraform-destroy - Execute terraform destroy in terraform files"
 	docker run --rm -v $(MODULE_DIR):/app -w /app/${TARGET_FOLDER} --env-file $(TARGET_ENV) hashicorp/terraform:$(TERRAFORM_VERSION) destroy -auto-approve
 
+terraform-sh: ## Access the terminal
+	echo "STEP: terraform-sh - Access the terminal"
+	docker run -it --rm -v $(MODULE_DIR):/app -w /app/${TARGET_FOLDER} --env-file $(TARGET_ENV) --entrypoint "" hashicorp/terraform:$(TERRAFORM_VERSION) sh
+
 fmt: terraform-fmt ## alias for terraform fmt
 plan: fmt terraform-init terraform-plan ## Execute terraform fmt, init, plan in terraform files
 apply: terraform-apply ## alias for terraform apply

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,10 @@ resource "google_compute_instance" "default" {
 
   metadata_startup_script = var.metadata_startup_script
 
+  metadata = {
+    ssh-keys = var.ssh_keys
+  }
+
   boot_disk {
     initialize_params {
       image = var.instance_image

--- a/main.tf
+++ b/main.tf
@@ -22,5 +22,15 @@ resource "google_compute_instance" "default" {
     network            = var.network
     subnetwork         = var.subnetwork
     subnetwork_project = var.project
+    access_config {
+      nat_ip = google_compute_address.default.address
+      network_tier = var.network_tier
+    }
   }
+}
+
+resource "google_compute_address" "default" {
+  project      = var.project
+  name = "ipv4-address-${var.instance_name}"
+  network_tier = var.network_tier
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,9 @@
+output "instance_public_ip" {
+  description = "The public IP of the instance"
+  value       = google_compute_instance.default[*].network_interface[*].access_config.0.nat_ip
+}
+
+output "instance_private_ip" {
+  description = "The private IP of the instance"
+  value       = google_compute_instance.default[*].network_interface[*].network_ip
+}

--- a/variables.tf
+++ b/variables.tf
@@ -50,3 +50,9 @@ variable "metadata_startup_script" {
   type        = string
   default     = ""
 }
+
+variable "ssh_keys" {
+  description = "Lista de chaves públicas para criar conta local juntamente com acesso SSH"
+  type = string
+  default = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -56,3 +56,9 @@ variable "ssh_keys" {
   type = string
   default = ""
 }
+
+variable "network_tier" {
+  description = "Nivel de serviço de rede. Opções: PREMIUM ou STANDARD"
+  type = string
+  default = "STANDARD"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,6 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.81.0"
     }
   }
 }


### PR DESCRIPTION
# Cria usuário e adiciona chave ssh

Adiciona parâmetro `metadata = { ssh-keys }` no resource
`google_compute_instance` para que seja possível a criação de um usuário
e conta com acesso SSH vinculado a uma chave pública. Houve mudanças no
`.env.terraform` para acomadar variáveis para o uso do Makefile, assim
como foram inseridas 4 novas funções no Makefile para criar conta de
serviço no GCP.

Signed-off-by: Danilo Figueiredo Rocha <snifbr@gmail.com>
Co-authored-by: Gabriel Iglesias <nerdtux@users.noreply.github.com>
Co-authored-by: Felipe Nobrega <lipenodias@users.noreply.github.com>

Revisores:
- @snifbr
- @marcio-machado76
- @vilelf
- @Rehzende
- @nerdtux
- @lipenodias
- @cflb


- [x] Garanta que seu **topic/feature/bugfix branch** tenha uma branch nomeada e não a sua branch main esteja no PR
- [x] Dê um titulo que expresse o objetivo do PR
- [x] Associe seu PR a uma Issue criada no repositósito. Caso seja uma correção de linguagem ou pequenas correções, não é necessário
- [x] Descreva o objetivo do PR
- [x] Inclua links relevantes para a sua modificação/sugestão/correção
- [x] Descreva um passo-a-passo para testar o seu PR

## Issue

#8 

## Objetivo

Criar um usuário local na VM com acesso SSH via chave pública.

## Referências

<https://cloud.google.com/compute/docs/instances/adding-removing-ssh-keys>
<https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance#metadata>
<https://stackoverflow.com/questions/38645002/how-to-add-an-ssh-key-to-an-gcp-instance-using-terraform>


## Como testar

Baixar o repositório:

```sh
git clone --branch metadata-ssh https://github.com/snifbr/iac-modulo-compute-gcp/tree/metadata-ssh
```

Entrar no diretório:

```sh
cd template-modulo-terraform/how-to-use-this-module
```

Substituir a(s) chave(s) pública(s) no arquivo `terrafile.tf` por alguma chave pública válida no formato especificado no arquivo `README.md` na raiz do repositório, para que você possa testar o acesso ao final.

Executar os comandos:

```sh
## 1: Criar Service Account no GCP
make auth-create-sa

## 2: Criar policy
make auth-create-iam-policy

## 3: Adicionar policy
make auth-create-add-policy

## 4: Gerar arquivo com chave para autenticar no GCP
make auth-create-creds-file

## 5: Executar o terraform
make plan
make apply
```

Acessar a VM que foi instanciada no GCP e verificar a criação de conta de usuário local desejado e do arquivo no HOME_DIR `.ssh/authorized_keys` contendo a chave pública.

```sh
## 5: Executar o terraform
make destroy

```

