### PR TITLE
fix: usa o recurso google_project_iam_binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ O formato é baseado no [Mantenha um Changelog](https://keepachangelog.com/pt-BR
 e este projeto segue o [Versionamento Semântico](https://semver.org/lang/pt-BR/spec/v2.0.0.html).
 
 ## [Não publicado]
+### Corrigido
+- Corrigido a associação de IAM roles com a service account [[GH-21](https://github.com/mentoriaiac/iac-modulo-compute-gcp/pull/21)]
 
 ## [0.2.0] 2021-11-06
 ### Adicionado
@@ -20,5 +22,5 @@ e este projeto segue o [Versionamento Semântico](https://semver.org/lang/pt-BR/
 - Criando a versão 0.1 do modulo de compute do GCP [[GH-1]](https://github.com/mentoriaiac/iac-modulo-compute-gcp/pull/1)
 
 [Não publicado]: https://github.com/mentoriaiac/iac-modulo-compute-gcp/compare/0.2.0...HEAD
-[0.2.0]: https://github.com/mentoriaiac/iac-modulo-compute-gcp/releases/tag/0.1.0
-
+[0.2.0]: https://github.com/mentoriaiac/iac-modulo-compute-gcp/releases/tag/0.2.0
+[0.1.0]: https://github.com/mentoriaiac/iac-modulo-compute-gcp/releases/tag/0.1.0

--- a/main.tf
+++ b/main.tf
@@ -44,13 +44,10 @@ resource "google_service_account" "sa" {
   display_name = var.instance_name
 }
 
-resource "google_project_iam_binding" "roles" {
+resource "google_project_iam_member" "roles" {
   for_each = toset(var.roles)
 
   project = var.project
   role    = "roles/${trimprefix(each.key, "roles/")}"
-  members = [
-    "serviceAccount:${google_service_account.sa.email}",
-  ]
-
+  member  = "serviceAccount:${google_service_account.sa.email}"
 }


### PR DESCRIPTION
A associção de IAM roles para service accounts em um project GCP pode
ser feito de várias formas, cada uma possui um recurso diferente.

A forma como estava sendo feita, usando o recurso
`google_project_iam_binding`, é indexada por role, o que significa que
só é possível ter um recurso por role por state.

Como esse módulo cria um service account automaticamente, se você usar o
módulo mais de uma vez haverá um conflito entre o binding de roles entre
as services accounts e só uma delas terá as roles corretas, a outra será
sobrescrita.

Co-authored-by: Danilo F Rocha <snifbr@gmail.com>
Co-authored-by: Felipe Nobrega <lipenodias@gmail.com>
Co-authored-by: Donato Horn <donatohorn@gmail.com>

- [x] Garanta que seu **topic/feature/bugfix branch** tenha uma branch nomeada e não a sua branch main esteja no PR
- [x] Dê um titulo que expresse o objetivo do PR
- [x] Associe seu PR a uma Issue criada no repositósito. Caso seja uma correção de linguagem ou pequenas correções, não é necessário
- [x] Descreva o objetivo do PR
- [x] Inclua links relevantes para a sua modificação/sugestão/correção
- [x] Descreva um passo-a-passo para testar o seu PR

## Issue

N/A

## Objetivo

Arrumar um problema que acontece quando o módulo é usado mais de uma vez.

## Referências

- https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project_iam#role

> Only one `google_project_iam_binding` can be used per role.

## Como testar

Criar uma configuração que cria mais de uma VM com roles:

```hcl
provider "google" {
  project = "<SEU PROJECT>"
  region  = "us-central1"
}

module "compute_gcp" {
  count = 2

  source         = "./.."
  project        = "<SEU PROJECT>"
  instance_name  = "instancia-${count.index}"
  instance_image = "debian-cloud/debian-10"
  machine_type   = "e2-small"
  zone           = "us-central1-a"
  network        = "default"

  roles = ["secretmanager.viewer"]

  labels = {
    value = "key"
  }

  tags = ["mentoriaiac"]
}
```
Verificar que a [lista de IAM](https://console.cloud.google.com/iam-admin/iam) possui um principal para cada máquina com a role de `Secret Manager Viewer`.