### PR TITLE
feat: Configuração de IP público

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ e este projeto segue o [Versionamento Semântico](https://semver.org/lang/pt-BR/
 
 ## [Não publicado]
 
+### Adicionado
+- Opção para configuração de IP público da instância [[GH-23](https://github.com/mentoriaiac/iac-modulo-compute-gcp/pull/23)]
+
 ## [0.2.1] - 2022-07-22
 
 ### Corrigido

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 | machine_type | Tipo de máquina na Google Cloud | `string` | n/a | sim |
 | network | Nome da rede existente na GCP | `string` | n/a | sim |
 | subnetwork | Nome da subrede existente na GCP * foi definido o valor padrão para caso passe a NETWORK com o valor 'default' | `string` | `""` | não |
+| public_ip | IP público fixo da máquina. Se for vazio, a máquina não terá IP público, se for `"ephemeral"` a máquina terá um IP dinâmico. | `string` | `""` | não |
 | zone | Zona na Google Cloud | `string` | n/a | sim |
 | ssh_keys | Lista de chaves públicas para criar conta local juntamente com acesso SSH, separadas por quebra de linha | `string` | "" | não |
 | labels | Mapa de labels para nossa instância maneira | `map(string)` | n/a | sim |

--- a/main.tf
+++ b/main.tf
@@ -26,9 +26,14 @@ resource "google_compute_instance" "default" {
     network            = var.network
     subnetwork         = var.subnetwork
     subnetwork_project = var.project
-    access_config {
-      nat_ip       = google_compute_address.default.address
-      network_tier = var.network_tier
+
+    dynamic "access_config" {
+      for_each = var.public_ip == "" ? [] : [var.public_ip]
+      iterator = ip
+      content {
+        nat_ip       = ip.value == "ephemeral" ? "" : ip.value
+        network_tier = var.network_tier
+      }
     }
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "instance_public_ip" {
   description = "The public IP of the instance"
-  value       = google_compute_instance.default[*].network_interface[*].access_config.0.nat_ip
+  value       = google_compute_instance.default[*].network_interface[*].access_config[*].nat_ip
 }
 
 output "instance_private_ip" {

--- a/variables.tf
+++ b/variables.tf
@@ -35,6 +35,12 @@ variable "subnetwork" {
   default     = ""
 }
 
+variable "public_ip" {
+  description = "IP público fixo da máquina. Se for vazio, a máquina não terá IP público, se for 'ephemeral' a máquina terá um IP dinâmico"
+  type        = string
+  default     = ""
+}
+
 variable "labels" {
   description = "Mapa de labels para nossa instância maneira"
   type        = map(string)

--- a/variables.tf
+++ b/variables.tf
@@ -36,7 +36,7 @@ variable "subnetwork" {
 }
 
 variable "public_ip" {
-  description = "IP público fixo da máquina. Se for vazio, a máquina não terá IP público, se for 'ephemeral' a máquina terá um IP dinâmico"
+  description = "IP público fixo da máquina. Se for vazio, a máquina não terá IP público, se for 'ephemeral' a máquina terá um IP dinâmico."
   type        = string
   default     = ""
 }


### PR DESCRIPTION
Adicionado variável public_ip para permitir controle de configuração do
ip público da máquina e o bloco dinamico de access_config.

Co-authored-by: Luiz Aoqui <lgfa29@gmail.com>
Co-authored-by: Ivo Menezes <ivorafaelm@gmail.com>
Co-authored-by: Guilherme Aparecido <kadeguilherme@gmail.com>
Co-authored-by: Antonio Fernandes <afernandescneto@gmail.com>
Co-authored-by: Donato Horn <donatohorn@gmail.com> @donato.horn
Co-authored-by: Danilo F Rocha <snifbr@gmail.com>

# Titulo

<!-- Por favor descreva seu pull request aqui. -->

- [x] Garanta que seu **topic/feature/bugfix branch** tenha uma branch nomeada e não a sua branch main esteja no PR
- [x] Dê um titulo que expresse o objetivo do PR
- [x] Associe seu PR a uma Issue criada no repositósito. Caso seja uma correção de linguagem ou pequenas correções, não é necessário
- [x] Descreva o objetivo do PR
- [x] Inclua links relevantes para a sua modificação/sugestão/correção
- [x] Descreva um passo-a-passo para testar o seu PR

## Issue
closes #22 

## Objetivo
Permitir customização de IP público no serviço de compute engine do GCP

## Referências
https://www.terraform.io/language/expressions/dynamic-blocks

## Como testar
No arquivo "terrafile.tf" alterar a variável "project" para o nome do projeto e incluir a variável "public_ip" informando vazio, ou ephemeral ou o IP desejado e rodar os comandos "terraform plan" e verificar a configuração do network interface, referenciando o "access_config" ou não, dependendo do valor informado